### PR TITLE
fix: resolve test suite isolation and unit test DB dependency bugs

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,13 +17,4 @@ def client(app):
     return app.test_client()
 
 
-@pytest.fixture(autouse=True)
-def clean_db():
-    # Truncate in reverse dependency order before each test
-    Event.delete().execute()
-    ShortURL.delete().execute()
-    User.delete().execute()
-    yield
-    Event.delete().execute()
-    ShortURL.delete().execute()
-    User.delete().execute()
+

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,0 +1,15 @@
+import pytest
+
+from app.models import Event, ShortURL, User
+
+
+@pytest.fixture(autouse=True)
+def clean_db(app):
+    # Truncate in reverse dependency order before each test
+    Event.delete().execute()
+    ShortURL.delete().execute()
+    User.delete().execute()
+    yield
+    Event.delete().execute()
+    ShortURL.delete().execute()
+    User.delete().execute()

--- a/tests/unit/test_short_code.py
+++ b/tests/unit/test_short_code.py
@@ -1,16 +1,24 @@
+from unittest.mock import patch, MagicMock
+
 from app.utils.short_code import generate_short_code
 
 
-def test_short_code_length_is_six():
+@patch("app.utils.short_code.ShortURL")
+def test_short_code_length_is_six(mock_model):
+    mock_model.select.return_value.where.return_value.exists.return_value = False
     code = generate_short_code()
     assert len(code) == 6
 
 
-def test_short_code_is_alphanumeric():
+@patch("app.utils.short_code.ShortURL")
+def test_short_code_is_alphanumeric(mock_model):
+    mock_model.select.return_value.where.return_value.exists.return_value = False
     code = generate_short_code()
     assert code.isalnum()
 
 
-def test_short_code_is_unique_across_calls():
+@patch("app.utils.short_code.ShortURL")
+def test_short_code_is_unique_across_calls(mock_model):
+    mock_model.select.return_value.where.return_value.exists.return_value = False
     codes = {generate_short_code() for _ in range(100)}
     assert len(codes) == 100


### PR DESCRIPTION
Two defects found during recording verification that caused test failures depending on how pytest was invoked.

Bug 1 — clean_db autouse fixture in wrong scope:
- clean_db was defined in tests/conftest.py (top-level) with autouse=True
- Unit tests don't call create_app(), leaving DatabaseProxy uninitialized
- All unit tests raised AttributeError: Cannot use uninitialized Proxy
- Fix: moved clean_db to tests/integration/conftest.py with app fixture dependency so it only fires for integration tests

Bug 2 — test_short_code.py queried DB without initialization:
- generate_short_code() calls ShortURL.select().where(...).exists() to check for collisions, requiring an initialized database connection
- Running tests/unit/ in isolation hit the uninitialized Proxy error
- Fix: mock ShortURL with @patch("app.utils.short_code.ShortURL") so tests/unit/ passes standalone without any database connection

Result: uv run pytest tests/unit/ passes (15 tests), uv run pytest tests/integration/ passes (31 tests), full suite unchanged at 46 passed.